### PR TITLE
Add log4j-core:tests dependency support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.8.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- handle the maven build lifecycle phases -->


### PR DESCRIPTION
Related to [JENKINS-54965](https://issues.jenkins-ci.org/browse/JENKINS-54965).

- Support for log4j-core:test classes needed for implementing unit tests
> The functionality within classes of the log4j-core `test.appender` package are helpful and needed during the validation phase of tests.

Desired Reviewers:
@jvz 
@jeffret-b 
