### PR TITLE
[JENKINS-55451] Update pom groupId path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <artifactId>audit-log</artifactId>
     <version>${revision}${changelist}</version>
+    <groupId>io.jenkins-ci.plugins</groupId>
     <packaging>hpi</packaging>
 
     <!-- scm information -->


### PR DESCRIPTION
See [JENKINS-55451](https://issues.jenkins-ci.org/browse/JENKINS-55451)

- Added new `groupId` to `pom.xml` `project` tag.

### Desired Reviewers:

@jvz 
@jeffret-b 