### PR TITLE
[JENKINS-55451] Fix: Correction to plugin groupId name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>audit-log</artifactId>
     <version>${revision}${changelist}</version>
-    <groupId>io.jenkins-ci.plugins</groupId>
+    <groupId>io.jenkins.plugins</groupId>
     <packaging>hpi</packaging>
 
     <!-- scm information -->


### PR DESCRIPTION
See discussion [comment](https://github.com/jenkins-infra/repository-permissions-updater/pull/980#discussion_r) and [JENKINS-55451](https://issues.jenkins-ci.org/browse/JENKINS-55451).

- Updated correction to `groupId` field; changing `io.jenkins-ci.plugins` to `io.jenkins.plugins`

### Desired Reviewers:

@jvz 
@jeffret-b 