### PR TITLE
[JENKINS-55489] Update jenkins upstream version to 2.161

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,7 @@
     <properties>
         <revision>1.0</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins-core.version>2.158-20190107.194411-1</jenkins-core.version>
-        <jenkins-war.version>2.158-20190107.194455-1</jenkins-war.version>
+        <jenkins.version>2.161</jenkins.version>
         <java.level>8</java.level>
         <log4j.version>2.11.1</log4j.version>
         <log4j-audit.version>1.0.1</log4j-audit.version>
@@ -161,10 +160,6 @@
         <repository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-        <repository>
-            <id>jenkins-2.158-snapshot</id>
-            <url>https://repo.jenkins-ci.org/snapshots/</url>
         </repository>
     </repositories>
     <pluginRepositories>


### PR DESCRIPTION
See [JENKINS-55489](https://issues.jenkins-ci.org/browse/JENKINS-55489).

- Updated project `pom.xml` jenkins version to `2.161`; which enables user-creation account listener support. ([Changelog notes](https://jenkins.io/changelog/#v2.161))

### Desired Reviewers:
@jvz 
@jeffret-b 