### PR TITLE
[Bug fix] [JENKINS-56172] Do not use JENKINS_HOME as variable name as it fails on priority fetches

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -17,8 +17,8 @@
 -->
 <Configuration status="ERROR">
     <Properties>
-        <Property name="JENKINS_HOME">$${env:JENKINS_HOME:-.}</Property>
-        <Property name="FALLBACK_LOG_DESTINATION">$${JENKINS_HOME}/logs/audit.log</Property>
+        <Property name="DEFAULT_HOME">$${env:JENKINS_HOME:-.}</Property>
+        <Property name="FALLBACK_LOG_DESTINATION">${DEFAULT_HOME}/logs/audit.log</Property>
         <Property name="AUDIT_LOG_DESTINATION">$${sys:auditFileName:-${FALLBACK_LOG_DESTINATION}}</Property>
     </Properties>
     <Appenders>


### PR DESCRIPTION
When we used JENKINS_HOME as also a property name it is not being fetched appropriately as it also clashes with the JENKINS_HOME env variable.