### PR TITLE
[JENKINS-56645] Log audit event for build finish

### DIFF
--- a/src/main/java/io/jenkins/plugins/audit/listeners/BuildListener.java
+++ b/src/main/java/io/jenkins/plugins/audit/listeners/BuildListener.java
@@ -9,6 +9,7 @@ import hudson.model.User;
 import hudson.model.listeners.RunListener;
 import org.apache.logging.log4j.audit.LogEventFactory;
 import io.jenkins.plugins.audit.event.BuildStart;
+import io.jenkins.plugins.audit.event.BuildFinish;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -16,7 +17,7 @@ import java.util.List;
 
 
 @Extension
-public class BuildStartListener extends RunListener<Run> {
+public class BuildListener extends RunListener<Run> {
     /**
      * Fired when a build is started, event logged via Log4j-audit.
      *
@@ -80,9 +81,9 @@ public class BuildStartListener extends RunListener<Run> {
 
 
     /**
-     * Returns a registered {@link BuildStartListener} instance.
+     * Returns a registered {@link BuildListener} instance.
      */
-    public static ExtensionList<BuildStartListener> getInstance() {
-        return ExtensionList.lookup(BuildStartListener.class);
+    public static ExtensionList<BuildListener> getInstance() {
+        return ExtensionList.lookup(BuildListener.class);
     }
 }

--- a/src/main/java/io/jenkins/plugins/audit/listeners/BuildListener.java
+++ b/src/main/java/io/jenkins/plugins/audit/listeners/BuildListener.java
@@ -68,7 +68,7 @@ public class BuildListener extends RunListener<Run> {
         buildFinish.setBuildNumber(run.getNumber());
         buildFinish.setCause(causes);
         buildFinish.setProjectName(run.getParent().getFullName());
-        buildFinish.setTimestamp(new Date(run.getStartTimeInMillis()).toString());
+        buildFinish.setTimestamp(new Date(run.getStartTimeInMillis() + run.getDuration()).toString());
         User user = User.current();
         if(user != null)
             buildFinish.setUserId(user.getId());

--- a/src/main/java/io/jenkins/plugins/audit/listeners/BuildListener.java
+++ b/src/main/java/io/jenkins/plugins/audit/listeners/BuildListener.java
@@ -48,6 +48,38 @@ public class BuildStartListener extends RunListener<Run> {
     }
 
     /**
+     * Fired when a build is completed, event logged via Log4j-audit.
+     *
+     * @param run of type Run having the build information
+     * @param listener of type TaskListener that the onCompleted method expects
+     */
+    @Override
+    public void onCompleted(Run run, TaskListener listener) {
+        BuildFinish buildFinish = LogEventFactory.getEvent(BuildFinish.class);
+
+        List causeObjects = run.getCauses();
+        List<String> causes = new ArrayList<>(causeObjects.size());
+        for (Object cause: causeObjects) {
+            Cause c = (Cause)cause;
+            causes.add(c.getShortDescription());
+        }
+
+        buildFinish.setBuildNumber(run.getNumber());
+        buildFinish.setCause(causes);
+        buildFinish.setProjectName(run.getParent().getFullName());
+        buildFinish.setTimestamp(new Date(run.getStartTimeInMillis()).toString());
+        User user = User.current();
+        if(user != null)
+            buildFinish.setUserId(user.getId());
+        else
+            buildFinish.setUserId(null);
+
+        buildFinish.logEvent();
+    }
+
+
+
+    /**
      * Returns a registered {@link BuildStartListener} instance.
      */
     public static ExtensionList<BuildStartListener> getInstance() {

--- a/src/main/resources/catalog.json
+++ b/src/main/resources/catalog.json
@@ -88,6 +88,28 @@
       "name" : "timestamp",
       "required" : false
     } ]
+  }, {
+    "id" : 7,
+    "name" : "buildFinish",
+    "displayName" : "Build Finish",
+    "description" : "Finish of the Build",
+    "aliases" : [ ],
+    "attributes" : [ {
+      "name" : "userId",
+      "required" : true
+    }, {
+      "name" : "cause",
+      "required" : false
+    }, {
+      "name" : "projectName",
+      "required" : true
+    }, {
+      "name" : "buildNumber",
+      "required" : true
+    }, {
+      "name" : "timestamp",
+      "required" : false
+    } ]
   } ],
   "attributes" : [ {
     "id" : 1,

--- a/src/test/java/io/jenkins/plugins/audit/listeners/BuildListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/audit/listeners/BuildListenerTest.java
@@ -43,6 +43,9 @@ public class BuildStartListenerTest {
 
         project.getBuildersList().add(new Shell("echo Test audit-log-plugin"));
         project.scheduleBuild2(0).get();
+        for(LogEvent e : events){
+            System.out.println(e.toString());
+        }
 
         assertEquals("Event on build start not triggered", 1, events.size());
     }

--- a/src/test/java/io/jenkins/plugins/audit/listeners/BuildListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/audit/listeners/BuildListenerTest.java
@@ -16,9 +16,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @RunWith(JUnitParamsRunner.class)
-public class BuildStartListenerTest {
+public class BuildListenerTest {
     private ListAppender app;
     private FreeStyleProject project;
 
@@ -36,17 +37,20 @@ public class BuildStartListenerTest {
         app.clear();
     }
 
-    @Issue("JENKINS-55608")
+    @Issue("JENKINS-55608, JENKINS-56645")
     @Test
-    public void testAuditOnBuildStart() throws Exception{
+    public void testAuditOnBuildStartAndFinish() throws Exception{
         List<LogEvent> events = app.getEvents();
 
         project.getBuildersList().add(new Shell("echo Test audit-log-plugin"));
         project.scheduleBuild2(0).get();
-        for(LogEvent e : events){
-            System.out.println(e.toString());
-        }
 
-        assertEquals("Event on build start not triggered", 1, events.size());
+        /*
+        Order of expected events
+        1) Start of the Build
+        2) Finish of the Build
+         */
+
+        assertEquals("Events on build start and complete not triggered", 2, events.size());
     }
 }


### PR DESCRIPTION
Audit event for the start of the build was already present in the plugin. I am modifying it to add an event for the finish of the build too.

Steps:

- [x] Add the event to the catalog

- [x] Override the listener method and log the event

- [x] Add/Modify the unit test to accommodate the changes.

See [JENKINS-56645](https://issues.jenkins-ci.org/browse/JENKINS-56645)

Requesting review with @jvz 

