### PR TITLE
Add the Intellij module file (iml) to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ buildNumber.properties
 .mvn/timing.properties
 .mvn/wrapper/maven-wrapper.jar
 work/
+
+# Editor files #
+*.iml


### PR DESCRIPTION
When building and analyzing this plugin, I noticed that it considered the IntelliJ module file, "audit-log.iml", as untracked. This augments the .gitignore to exclude it.