### PR TITLE
Replace Jackson dependency with plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,33 @@
     <!-- defines all project dependencies -->
     <dependencies>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+            <version>2.9.9.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-audit-api</artifactId>
             <version>${log4j-audit.version}</version>
+            <exclusions>
+                <!-- all provided by jackson2-api plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -63,6 +87,25 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-catalog-api</artifactId>
             <version>${log4j-audit.version}</version>
+            <exclusions>
+                <!-- all provided by jackson2-api plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- fixes log4j-catalog-api commons-lang3 version mismatch issue -->
         <dependency>
@@ -75,6 +118,7 @@
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
             <version>1.1.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -99,6 +143,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mock-security-realm</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>


### PR DESCRIPTION
This uses the Jenkins plugin that bundles Jackson in order to avoid
having to upgrade outdated versions of Jackson in every plugin that uses
it.

This closes #56.