### PR TITLE
SizeBasedTriggeringPolicy added to audit.html file

### DIFF
--- a/src/main/java/io/jenkins/plugins/audit/config/AuditConfigurationFactory.java
+++ b/src/main/java/io/jenkins/plugins/audit/config/AuditConfigurationFactory.java
@@ -36,6 +36,7 @@ public class AuditConfigurationFactory extends ConfigurationFactory {
                         .addAttribute("charset", "UTF-8")
                         .addAttribute("locationInfo", false))
                 .addComponent(builder.newComponent("TimeBasedTriggeringPolicy"))
+                .addComponent(builder.newComponent("SizeBasedTriggeringPolicy").addAttribute("size", "50 MB"))
                 .addComponent(builder.newComponent("DefaultRolloverStrategy").addAttribute("max", 30)));
         // not trying to pollute any logs here
         builder.add(builder.newRootLogger(Level.OFF));


### PR DESCRIPTION
Entries in file audit.html grow out of hand on a more busy jenkins server and there's no sized based rotation. This caused quite a lot of unnecessary disk usage. 