### PR TITLE
Updating log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <log4j-audit.version>1.0.1</log4j-audit.version>
         <junit.version>4.13.1</junit.version>
         <credentials.version>2.3.19</credentials.version>


### PR DESCRIPTION
Updating log4j version to address the Security Vulnerability CVE-2021-44832

https://logging.apache.org/log4j/2.x/
